### PR TITLE
feat: :art: Adicionado dados no readme e novos commands para iniciar o container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 
 3. Abra um terminal de comando dentro da pasta **consulta-cep-infra** e digite
 `docker-compose up -d`
+4. Aguarde finalizar e aguarde o mvn rodar as instalações necessárias e iniciar a API.
+
 
 [Link da API](https://github.com/lucasmenescal/consulta-endereco)
 
+
+### Requisitos
+> Ter o docker e o docker-compose instalados na maquina.
+
+### Observações importantes
+1. Para conseguir rodar os testes Junit5, Cucumber é necessário comentar a linha `command: mvn spring-boot:run` do docker-compose e descomentar `command: /bin/bash`
+2. Em seguida, deverá abrir um vscode dentro do container, com a extensao Dev containers.
+3. Abrir um terminal dentro do container e digitar `mvn test`
+
+### Para acessar a Documentação Swagger
+1. Quando a API estiver rodando dentro do container acesse o link:
+[Documentação Swagger](http://localhost:8080/swagger-ui/index.html)

--- a/calcula-frete-infra/Dockerfile
+++ b/calcula-frete-infra/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /workspace
 WORKDIR /workspace/consulta-endereco
 
 # Executa o projeto
-CMD ["mvn", "spring-boot:run"]
+# CMD ["mvn", "spring-boot:run"]
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
     container_name: calcula-frete
     volumes:
       - ./calcula-frete-infra/projeto/:/workspace
-    restart: always
     ports:
       - "8080:8080"
     stdin_open: true   
+    # command: mvn spring-boot:run
+    # command: mvn test
     command: /bin/bash
 


### PR DESCRIPTION
Adicionado linhas de command para:
1. Iniciar o projeto
2. Rodar teste do projeto(mas só rodou o junit5)
3. Manter container iniciado para acessar com dev container do vscode.
4. Modificações no readme
